### PR TITLE
Fix SSL

### DIFF
--- a/lib/nrpeclient/nrpe_packet.rb
+++ b/lib/nrpeclient/nrpe_packet.rb
@@ -61,11 +61,11 @@ module Nrpeclient
       [ @packet_version, @packet_type, use_crc32, @result_code, @buffer, @random].pack("nnNna#{MAX_PACKETBUFFER_LENGTH}n")
     end
 
-    def self.read(io)
+    def self.read(io, validate_crc32=true)
       bytes = io.read(MAX_PACKET_SIZE)
       values = bytes.unpack("nnNnA#{MAX_PACKETBUFFER_LENGTH}n")
       packet = self.new(values)
-      packet.validate_crc32
+      packet.validate_crc32 if validate_crc32
       packet
     end
   end

--- a/lib/nrpeclient/version.rb
+++ b/lib/nrpeclient/version.rb
@@ -1,3 +1,3 @@
 module Nrpeclient
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Hiya,

I stumbled across this looking for a solution for nrpe in a ruby application that was less ugly than shell execing!

SSL was a bit broken - a few syntax errors and hardcoded certificate paths, as well as using deprecated/nonexistent `#version=`. I fixed that up and ran into some CRC32 errors when using SSL.

Considering we're using SSL and the protocol makes its own guarantees about data consistency, I figured the path of least resistance would be to skip the CRC validation if we're using SSL. Totally open to scrapping that idea if you have a better idea on how to fix it, but figured I'd send this back your way to help out.

Let me know if there's anything you'd like me to change to get this merged in.

Cheers!
James
