### PR TITLE
Error proofing SSL and exposing perfdata

### DIFF
--- a/lib/nrpeclient/check_nrpe.rb
+++ b/lib/nrpeclient/check_nrpe.rb
@@ -15,8 +15,8 @@ module Nrpeclient
       if @options[:ssl]
         @ssl_context = OpenSSL::SSL::SSLContext.new :SSLv23
         @ssl_context.ciphers = 'ADH'
-        @ssl_context.cert = OpenSSL::X509::Certificate.new(File.open(@options.fetch(:ssl_cert)))
-        @ssl_context.key = OpenSSL::PKey::RSA.new(File.open(@options.fetch(:ssl_key)))
+        @ssl_context.cert = OpenSSL::X509::Certificate.new(File.open(@options.fetch(:ssl_cert))) if !@options[:ssl_cert].nil?
+        @ssl_context.key = OpenSSL::PKey::RSA.new(File.open(@options.fetch(:ssl_key))) if !@options[:ssl_key].nil?
       end
     end
 

--- a/lib/nrpeclient/nrpe_packet.rb
+++ b/lib/nrpeclient/nrpe_packet.rb
@@ -26,6 +26,15 @@ module Nrpeclient
         @result_code    = unpacked[3]
         @buffer         = unpacked[4]
         @random         = unpacked[5]
+        # Parse perfdata and return as a hash
+        if @buffer.include? "|" then
+          @perfdata = Hash.new
+          @buffer.split("|")[1].split(",").each do |metric|
+            key = metric.split("=")[0].strip
+            value = metric.split("=")[1].strip
+            @perfdata[:"#{key}"] = value
+          end
+        end
       end
     end
 

--- a/lib/nrpeclient/nrpe_packet.rb
+++ b/lib/nrpeclient/nrpe_packet.rb
@@ -13,7 +13,7 @@ module Nrpeclient
 
     MAX_PACKET_SIZE = 12 + 1024
 
-    attr_accessor :packet_version, :crc32, :result_code, :buffer
+    attr_accessor :packet_version, :crc32, :result_code, :buffer, :perfdata
 
     def initialize(unpacked=nil)
       @packet_version = NRPE_PACKET_VERSION_2
@@ -26,6 +26,15 @@ module Nrpeclient
         @result_code    = unpacked[3]
         @buffer         = unpacked[4]
         @random         = unpacked[5]
+        # Parse perfdata and return as a hash
+        if @buffer.include? "|" then
+          @perfdata = Hash.new
+          @buffer.split("|")[1].split(",").each do |metric|
+            key = metric.split("=")[0].strip
+            value = metric.split("=")[1].strip
+            @perfdata[:"#{key}"] = value
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Thanks for writing a great class/gem! Outside of this request, could you please rebuild and repush the gem to rubygems.org, seems like the one currently there is a bit out of date.

I've had to make a couple changes to make it work for our environment -
(1) Adding support for using default key and certificate in the SSL context. One can still be provided, but there is no exception if it isn't.
(2) Exposing perfdata via an object returned from the NRPE packet. 

None of these changes will affect existing functionality.
